### PR TITLE
⚠️ Major Fixes on SimulaCovid

### DIFF
--- a/src/pages/main.py
+++ b/src/pages/main.py
@@ -448,6 +448,11 @@ def main():
 
     if product == "SimulaCovid":
         user_analytics.log_event("picked simulacovid", dict())
+        # Downloading the saved data from memory
+        user_input["number_beds"] = session_state.number_beds
+        user_input["number_ventilators"] = session_state.number_ventilators
+        user_input["number_deaths"] = session_state.number_deaths
+        user_input["number_cases"] = session_state.number_cases
         sm.main(user_input, indicators, data, config, session_state)
         # TODO: remove comment on this later!
         # utils.gen_pdf_report()

--- a/src/pages/main.py
+++ b/src/pages/main.py
@@ -90,29 +90,18 @@ def update_indicators(indicators, data, config, user_input, session_state):
                 indicators[group].right_display = "- "
                 indicators[group].left_display = "- "
 
-    # Update session values
-    if (session_state.state != user_input["state_name"]) or (
-        session_state.city != user_input["city_name"]
-    ):
-        session_state.state = user_input["state_name"]
-        session_state.city = user_input["city_name"]
-        session.number_beds = user_input["number_beds"]
-        session.number_ventilators = user_input["number_ventilators"]
-        session.cases = user_input["population_params"]["I_confirmed"]
-
-    if (
-        session_state.number_beds != None and session_state.reset is False
-    ):  # Loading values from memory
-        indicators["subnotification_rate"].left_display = session_state.number_cases
-
-        indicators["hospital_capacity"].left_display = int(
-            session_state.number_beds
-            / config["br"]["simulacovid"]["resources_available_proportion"]
-        )
-        indicators["hospital_capacity"].right_display = int(
-            session_state.number_ventilators
-            / config["br"]["simulacovid"]["resources_available_proportion"]
-        )
+    # if (
+    # session_state.number_beds != None and session_state.reset is False
+    # ):  # Loading values from memory
+    indicators["subnotification_rate"].left_display = session_state.number_cases
+    indicators["hospital_capacity"].left_display = int(
+        session_state.number_beds
+        # config["br"]["simulacovid"]["resources_available_proportion"]
+    )
+    indicators["hospital_capacity"].right_display = int(
+        session_state.number_ventilators
+        # config["br"]["simulacovid"]["resources_available_proportion"]
+    )
 
     # Recalcula capacidade hospitalar
     user_input["strategy"] = "estavel"
@@ -122,7 +111,7 @@ def update_indicators(indicators, data, config, user_input, session_state):
         run_simulation(user_input, config),
         "I2",
         user_input["number_beds"]
-        * config["br"]["simulacovid"]["resources_available_proportion"],
+        # * config["br"]["simulacovid"]["resources_available_proportion"],
     )["best"]
 
     # TODO: add no config e juntar com farol
@@ -258,6 +247,26 @@ def main():
     }
 
     user_input["last_updated_cases"] = data["last_updated_subnotification"].max()
+    # Update session values to standard ones if changed city or opened page or reseted values
+    if (
+        session_state.state != user_input["state_name"]
+        or session_state.city != user_input["city_name"]
+        or session_state.number_beds is None
+        or session_state.reset
+    ):
+        session_state.state = user_input["state_name"]
+        session_state.city = user_input["city_name"]
+        session_state.number_beds = int(
+            user_input["number_beds"]
+            * config["br"]["simulacovid"]["resources_available_proportion"]
+        )
+        session_state.number_ventilators = int(
+            user_input["number_ventilators"]
+            * config["br"]["simulacovid"]["resources_available_proportion"]
+        )
+        session_state.number_cases = user_input["population_params"]["I_confirmed"]
+        session_state.number_deaths = user_input["population_params"]["D"]
+        session_state.reset = True
 
     if data["confirmed_cases"].sum() == 0:
         st.write(

--- a/src/pages/simulacovid.py
+++ b/src/pages/simulacovid.py
@@ -112,8 +112,10 @@ def main(user_input, indicators, data, config, session_state):
 
         # Caso o usuário altere os casos confirmados, usamos esse valor para a estimação
 
-        if (session_state.cases is not None) and (session_state.cases != user_input["population_params"]["I_compare"]):
-            user_input["population_params"]["I"] = session_state.cases
+        if (session_state.number_cases is not None) and (
+            session_state.number_cases != user_input["population_params"]["I_compare"]
+        ):
+            user_input["population_params"]["I"] = session_state.number_cases
 
         dfs = simulator.run_simulation(user_input, config)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -105,7 +105,6 @@ def get_sources(user_input, data, cities_sources, resources):
     user_input["last_updated_number_ventilators"] = pd.to_datetime(
         user_input["last_updated_number_ventilators"]
     ).strftime("%d/%m")
-
     # user_input["n_beds"] = sources["number_beds"][0]
     # user_input["n_ventilators"] = sources["number_ventilators"][0]
 


### PR DESCRIPTION
Fixes:
- **Rt wasn't changing with the choice of (1) scenarios or (2) cases.** 
   - (1) There was some errors on code for state Rt selection when the city didn't have one, now it's working the way it should behave! 
   - (2) A lot of work here to keep to not mix around the data with session_states: basically we use `active_cases` by default, but the user change the value for `confirmed_cases` on the selector... I added a user_input variable to keep the `confirmed_cases` and compare if the user changed it, to change on session_state. I don't think it's the better way to solve it though.

- **We were hidden values of cases & capacity when the city didn't have the respective indicator**. I changed it on `update_indicators` function, it seems right now - I did some checking with cities like Porto Walter (AC), but it's better to double check.

Addition:
- Change the `strategy` names to our new scenarios

**TODO:**
- The values for beds & ventilators changed by users are getting divided by half on simulation