### PR TITLE
Major update changing how we identify amplitude users

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,5 @@ psutil
 google-api-python-client
 google-auth-httplib2
 google-auth-oauthlib
-oauth2client 
+oauth2client
+ua-parser

--- a/src/amplitude.py
+++ b/src/amplitude.py
@@ -4,98 +4,15 @@ import json
 import os
 import amplitude
 import utils
+import datetime
 
-ipinfo_url = "https://geolocation-db.com/json/"
 headers = {"Content-Type": "application/json", "Accept": "*/*"}
 
 r = requests.post("https://api.amplitude.com/2/httpapi", params={}, headers=headers)
 
-names = [  # Please keep this at a length equal to a prime at ALL TIMES
-    "ho",
-    "jung",
-    "kim",
-    "pak",
-    "lee",
-    "su",
-    "chi",
-    "san",
-    "ne",
-    "po",
-    "koi",
-    "sen",
-    "kai",
-    "ki",
-    "xu",
-    "wu",
-    "han",
-    "nem",
-    "lil",
-    "sa",
-    "ka",
-    "goi",
-    "pan",
-    "yi",
-    "choi",
-    "min",
-    "joi",
-    "ye",
-    "joo",
-    "young",
-    "il",
-    "koto",
-    "buran",
-    "soto",
-    "iji",
-    "shima",
-    "naru",
-    "to",
-    "iwo",
-    "oki",
-    "ya",
-    "ma",
-    "waza",
-    "mura",
-    "jima",
-    "uji",
-    "sama",
-    "uzu",
-    "maki",
-    "ko",
-    "hideo",
-    "saki",
-    "mate",
-]
-
-# Changing this function means probably ERASING ALL OF OUR USER DATA, SO PROCEED CAREFULLY
-def hash_mock_name(ip):
-    total = 1
-    parts = [int(i) for i in ip.split(".")]
-    for char in ip:
-        total = total * ord(char)
-    size = len(names)
-    pos1 = total % size
-    pos2 = (total * parts[0] + 929) % size
-    pos3 = (total * parts[0] * 349 * parts[1] + 571) % size
-    pos4 = (total * parts[1] * 571 * +parts[2] * 191 + 571) % size
-    pos5 = (total * parts[1] * 487 * +parts[2] * 571 + parts[3] * 199 + 929) % size
-    pos6 = (
-        total * parts[0] * 929 * +parts[1] * 199 + parts[3] * 383 + parts[2] * 929 + 571
-    ) % size
-    name = (
-        names[pos1]
-        + names[pos2]
-        + " "
-        + names[pos3]
-        + names[pos4]
-        + " "
-        + names[pos5]
-        + names[pos6]
-    )
-    # print(name)
-    return name
-
 
 def gen_user(current_server_session):
+    """ Returns the current user on the page as our Amplitude User Object"""
     data = utils.parse_headers(current_server_session.ws.request)
     user_data = {"has_precise_ip": False}
     if "user_public_data" in data["Cookie"].keys():
@@ -118,8 +35,13 @@ class Amplitude_user:
         self.user_data = inuser_data
 
     def log_event(self, event, event_args=dict()):
+        """
+         To be called directly only in areas with no external reruns
+         like inside buttons for example.
+         For other circusmtances use the safe version.
+        """
+        # print("logging : " + event + " at " + str(datetime.datetime.now()))
         event_data = {"user_id": self.user_data["user_id"]}
-        # print(self.name + " has " + event)
         event_data["event_type"] = event
         event_data["user_properties"] = event_args
         event_data["ip"] = self.user_data["ip"]
@@ -135,3 +57,87 @@ class Amplitude_user:
             "https://api.amplitude.com/2/httpapi", json=request_data, headers=headers
         )
         return response.json()
+
+    def safe_log_event(  # For use in areas subject to various reruns
+        self,
+        event,
+        session_state,
+        event_args=dict(),
+        is_new_page=False,
+        alternatives=[],
+    ):
+        """
+        Receives the call for an event but decides if the event is worth logging or not by using our session makeshift db.
+        This is to avoid us logging multiple times the same event when the page reloads.
+        If the item is inside a button you can use the normal version, but otherwise it is recommended to use this one.
+
+        is_new_page is a boolean telling if this event is the user moving to a new page, in which case the code
+        will detect if this event is not repeated and then if it is not it will reset all the other values and log the page change.
+
+        alternatives is a list of alternate events that could have happened instead of this one (for example when choosing a a scenario
+        in simulacovid). This is such that we can keep track of what option is chosen at the current moment by making the chosen option
+        True and the rest False.
+
+        For the rest of the events it will try to use the event_args object and detect any changes from the previous ones.
+        If a change is detected it will log the event, if not it will ignore.
+
+        Alternatively it can trigger empty event_args events by checking if it is True or False, if it is False then we log and
+        make it True. If it is True we ignore."""
+        if session_state.amplitude_events is None:
+            session_state.amplitude_events = dict()
+            session_state.old_amplitude_events = dict()
+        if (
+            is_new_page
+        ):  # If it is the opening of a new page we only register the event if the opening is really new
+            if (
+                event not in session_state.old_amplitude_events.keys()
+                or session_state.old_amplitude_events[event] is not True
+            ):  # If the page wasnt opened before or is brand new event
+                for (
+                    key
+                ) in session_state.old_amplitude_events.keys():  # Reset the old dict
+                    session_state.old_amplitude_events[key] = None
+                session_state.old_amplitude_events[
+                    event
+                ] = True  # Say that he have opened the page
+                session_state.amplitude_events[
+                    event
+                ] = True  # Say that we will keep it open
+                self.log_event(event, event_args)  # Log the event
+        else:  # If it is not a new page we have to check for differences in the state
+            if (
+                event not in session_state.old_amplitude_events.keys()
+                # If the event is brand new
+                or (
+                    session_state.old_amplitude_events[event] is None
+                    # If the event had been reseted
+                    or session_state.old_amplitude_events[event] is False
+                    # If the even was inactive or not chosen
+                    or (
+                        session_state.old_amplitude_events[event] not in [True, False]
+                        and session_state.old_amplitude_events[event] != event_args
+                    )
+                )  # If the event has been changed
+            ):
+                self.log_event(event, event_args)  # Log the event
+                if len(event_args.keys()) == 0:  # If the event comes in empty
+                    session_state.amplitude_events[event] = True
+                else:  # Else we save the relevant data to look for changes later
+                    session_state.amplitude_events[event] = event_args
+                for alternative in alternatives:
+                    # If we have alternatives we must make sure to mark them all as not chosen
+                    if alternative != event:
+                        session_state.amplitude_events[alternative] = False
+
+    def conclude_user_session(
+        self, session_state
+    ):  # Once we finish loading it all turn the old into new
+        """ 
+        This function is essential for pages that have mutiple amplitude events that can trigger reruns.
+        If your page does more than logging at loading, it should add this to the end of the page so that
+        when we load the entire page we can make sure to make throw the current values into the old values object
+        and begin a new one. This means effectively updating our manager saying that the entire page loaded sucessfully
+        and that now we should look into the future.
+        """
+        session_state.old_amplitude_events = dict(session_state.amplitude_events)
+

--- a/src/amplitude.py
+++ b/src/amplitude.py
@@ -5,6 +5,7 @@ import os
 import amplitude
 import utils
 import datetime
+from ua_parser import user_agent_parser
 
 headers = {"Content-Type": "application/json", "Accept": "*/*"}
 
@@ -25,7 +26,9 @@ def gen_user(current_server_session):
         user_data["user_id"] = data["Cookie"]["user_unique_id"]
     else:
         user_data["user_id"] = "anonymous"
-
+    for inkey in data.keys():
+        if inkey[:3] == "ua_":
+            user_data[inkey] = data[inkey]
     return Amplitude_user(os.getenv("AMPLITUDE_KEY"), user_data)
 
 
@@ -52,6 +55,9 @@ class Amplitude_user:
             event_data["location_lat"] = self.user_data["latitude"]
             event_data["location_lng"] = self.user_data["longitude"]
             event_data["carrier"] = self.user_data["isp"]
+        for inkey in self.user_data.keys():
+            if inkey[:3] == "ua_":
+                event_data[inkey[3:]] = self.user_data[inkey]
         request_data = {"api_key": self.key, "events": [event_data]}
         response = requests.post(
             "https://api.amplitude.com/2/httpapi", json=request_data, headers=headers

--- a/src/amplitude.py
+++ b/src/amplitude.py
@@ -46,27 +46,29 @@ class Amplitude_user:
         # print("logging : " + event + " at " + str(datetime.datetime.now()))
         event_data = {
             "user_id": self.user_data["user_id"],
-            "device_id": self.user_data["user_id"],
+            "event_type": event,
+            "event_properties": event_args,
+            "ip": self.user_data["ip"],
+            # "device_id": self.user_data["user_id"],
         }
         request_data = dict()
-        event_data["event_type"] = event
-        event_data["user_properties"] = event_args
-        request_data["ip"] = self.user_data["ip"]
         if self.user_data["has_precise_ip"]:
-            request_data["country"] = self.user_data["country_name"]
-            request_data["region"] = self.user_data["region"]
-            request_data["city"] = self.user_data["city"]
-            request_data["location_lat"] = self.user_data["latitude"]
-            request_data["location_lng"] = self.user_data["longitude"]
-            request_data["carrier"] = self.user_data["isp"]
+            event_data["dma"] = self.user_data["city"]
+            event_data["country"] = self.user_data["country_name"]
+            event_data["region"] = self.user_data["region"]
+            event_data["city"] = self.user_data["city"]
+            event_data["location_lat"] = self.user_data["latitude"]
+            event_data["location_lng"] = self.user_data["longitude"]
+            event_data["carrier"] = self.user_data["isp"]
         for inkey in self.user_data.keys():
             if inkey[:3] == "ua_":
-                request_data[inkey[3:]] = self.user_data[inkey]
+                event_data[inkey[3:]] = self.user_data[inkey]
         request_data["api_key"] = self.key
         request_data["events"] = [event_data]
         response = requests.post(
             "https://api.amplitude.com/2/httpapi", json=request_data, headers=headers
         )
+        # print(request_data)
         # print(response.json())
         return response.json()
 

--- a/src/farolcovid.py
+++ b/src/farolcovid.py
@@ -48,6 +48,9 @@ def main():
     # in each state, the value will be something that allows us to identify there is a change or not
     # which in turn allows us to decide if we should log the event or not"""
     utils.manage_user_existence(utils.get_server_session(), session_state)
+    utils.update_user_public_info()
+    u_data = utils.parse_headers(utils.get_server_session().ws.request)
+    # st.write(u_data)
     page = st.sidebar.radio(
         "Menu",
         [

--- a/src/farolcovid.py
+++ b/src/farolcovid.py
@@ -21,9 +21,27 @@ import pages.main as fc
 import pages.risk_description as rd
 import pages.rt_description as rt
 import pages.saude_em_ordem_description as sod
+import utils
+import session
 
 
 def main():
+    session_state = session.SessionState.get(
+        key=session.get_user_id(),
+        update=False,
+        number_beds=None,
+        number_ventilators=None,
+        number_cases=None,
+        number_deaths=None,
+        state="Acre",
+        city="Todos",
+        refresh=False,
+        reset=False,
+        saude_ordem_data=None,
+        already_generated_user_id=None,
+        pages_open=None,
+    )
+    utils.manage_user_existence(utils.get_server_session(), session_state)
     page = st.sidebar.radio(
         "Menu",
         [
@@ -43,7 +61,7 @@ def main():
 
     elif page == "FarolCovid":
         if __name__ == "__main__":
-            fc.main()
+            fc.main(session_state)
 
     elif page == "Análises":
         if __name__ == "__main__":

--- a/src/farolcovid.py
+++ b/src/farolcovid.py
@@ -26,6 +26,7 @@ import session
 
 
 def main():
+    # Defines the db structure of our makeshift session db
     session_state = session.SessionState.get(
         key=session.get_user_id(),
         update=False,
@@ -40,7 +41,12 @@ def main():
         saude_ordem_data=None,
         already_generated_user_id=None,
         pages_open=None,
+        amplitude_events=None,
+        old_amplitude_events=None,
     )
+    # In those amplitude events objects we are going to save a dict with every state as keys
+    # in each state, the value will be something that allows us to identify there is a change or not
+    # which in turn allows us to decide if we should log the event or not"""
     utils.manage_user_existence(utils.get_server_session(), session_state)
     page = st.sidebar.radio(
         "Menu",
@@ -57,7 +63,7 @@ def main():
 
     if page == "Modelo Epidemiológico":
         if __name__ == "__main__":
-            md.main()
+            md.main(session_state)
 
     elif page == "FarolCovid":
         if __name__ == "__main__":
@@ -65,22 +71,22 @@ def main():
 
     elif page == "Análises":
         if __name__ == "__main__":
-            anal.main()
+            anal.main(session_state)
 
     elif page == "Quem somos?":
         if __name__ == "__main__":
-            tm.main()
+            tm.main(session_state)
 
     elif page == "Níveis de Risco":
         if __name__ == "__main__":
-            rd.main()
+            rd.main(session_state)
 
     elif page == "Estimando Ritmo de Contágio":
         if __name__ == "__main__":
-            rt.main()
+            rt.main(session_state)
     elif page == "Metodologia do Saúde em Ordem":
         if __name__ == "__main__":
-            sod.main()
+            sod.main(session_state)
 
 
 if __name__ == "__main__":

--- a/src/farolcovid.py
+++ b/src/farolcovid.py
@@ -23,10 +23,13 @@ import pages.rt_description as rt
 import pages.saude_em_ordem_description as sod
 import utils
 import session
+import time
 
 
 def main():
     # Defines the db structure of our makeshift session db
+    time.sleep(0.05)
+    # Minimal wait time so we give time for the user session to appear in steamlit
     session_state = session.SessionState.get(
         key=session.get_user_id(),
         update=False,
@@ -49,8 +52,6 @@ def main():
     # which in turn allows us to decide if we should log the event or not"""
     utils.manage_user_existence(utils.get_server_session(), session_state)
     utils.update_user_public_info()
-    u_data = utils.parse_headers(utils.get_server_session().ws.request)
-    # st.write(u_data)
     page = st.sidebar.radio(
         "Menu",
         [

--- a/src/pages/data_analysis.py
+++ b/src/pages/data_analysis.py
@@ -240,9 +240,11 @@ def prepare_heatmap(df, place_type, group=None, mavg_days=5):
     )
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened analysis")
+    opening_response = user_analytics.safe_log_event(
+        "opened analysis", session_state, is_new_page=True
+    )
     utils.localCSS("style.css")
     utils.localCSS("icons.css")
 

--- a/src/pages/main.py
+++ b/src/pages/main.py
@@ -181,24 +181,11 @@ def get_data(config):
     )
 
 
-def main():
+def main(session_state):
 
     # Get user info
     user_analytics = amplitude.gen_user(utils.get_server_session())
     opening_response = user_analytics.log_event("opened farol", dict())
-    session_state = session.SessionState.get(
-        key=session.get_user_id(),
-        update=False,
-        number_beds=None,
-        number_ventilators=None,
-        number_cases=None,
-        number_deaths=None,
-        state="Acre",
-        city="Todos",
-        refresh=False,
-        reset=False,
-        saude_ordem_data=None,
-    )
 
     utils.localCSS("style.css")
 
@@ -448,11 +435,9 @@ def main():
     products = ProductCards
     products[1].recommendation = f'Risco {data["overall_alert"].values[0]}'
     utils.genProductsSection(products)
-
     product = st.selectbox(
         "", ["Como você gostaria de prosseguir?", "SimulaCovid", "Saúde em Ordem",],
     )
-
     if product == "SimulaCovid":
         user_analytics.log_event("picked simulacovid", dict())
         # Downloading the saved data from memory
@@ -463,7 +448,6 @@ def main():
         sm.main(user_input, indicators, data, config, session_state)
         # TODO: remove comment on this later!
         # utils.gen_pdf_report()
-
     elif product == "Saúde em Ordem":
         user_analytics.log_event("picked saude_em_ordem", dict())
         so.main(user_input, indicators, data, config, session_state)

--- a/src/pages/main.py
+++ b/src/pages/main.py
@@ -100,6 +100,14 @@ def update_indicators(indicators, data, config, user_input, session_state):
         session_state.number_ventilators
     )
 
+    # Caso o usuário altere os casos confirmados, usamos esse novo valor para a estimação
+    # TODO: vamos acabar com o user_iput e manter só session_state?
+    if (session_state.number_cases is not None) and (
+        session_state.number_cases != user_input["population_params"]["I_compare"]
+    ):
+        user_input["population_params"]["I"] = session_state.number_cases
+        user_input["population_params"]["D"] = session_state.number_cases
+
     # Recalcula capacidade hospitalar
     user_input["strategy"] = "estavel"
     user_input = sm.calculate_recovered(user_input, data)

--- a/src/pages/model_description.py
+++ b/src/pages/model_description.py
@@ -5,9 +5,11 @@ import amplitude
 import utils
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened model")
+    opening_response = user_analytics.safe_log_event(
+        "opened model", session_state, is_new_page=True
+    )
     st.header("Metodologia")
 
     st.write("v1.3 - Atualizações")

--- a/src/pages/risk_description.py
+++ b/src/pages/risk_description.py
@@ -6,9 +6,11 @@ import amplitude
 import utils
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened risk_level")
+    opening_response = user_analytics.safe_log_event(
+        "opened risk_level", session_state, is_new_page=True
+    )
     st.header("""Níveis de Risco: como saber se estou no controle da Covid-19?""")
 
     st.write(

--- a/src/pages/rt_description.py
+++ b/src/pages/rt_description.py
@@ -3,9 +3,11 @@ import amplitude
 import utils
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened spread_rhythm")
+    opening_response = user_analytics.safe_log_event(
+        "opened spread_rhythm", session_state, is_new_page=True
+    )
     st.header("""$$R_t$$ de Estados e Municípios""")
 
     st.subheader("""Calculo do $$R_t$$""")

--- a/src/pages/saude_em_ordem.py
+++ b/src/pages/saude_em_ordem.py
@@ -197,7 +197,7 @@ def gen_sector_plot_card(sector_name, sector_data, size_sectors=5):
         <div class="saude-plot-group-massa-salarial-value">R$ {convert_money(average_wage)}</div>
         <div class="saude-plot-group-separator-line"></div>
         <div class="saude-plot-group-pessoas-label">Número de pessoas: </div>
-        <div class="saude-plot-group-pessoas-value">{num_people}</div>
+        <div class="saude-plot-group-pessoas-value">{convert_money(num_people)}</div>
     </div>"""
     return text
 
@@ -225,6 +225,11 @@ def gen_slider(session_state):
     )
     session_state.saude_ordem_data["slider_value"] = st.slider(
         "Selecione o valor abaixo", 70, 100, step=10
+    )
+    amplitude.gen_user(utils.get_server_session()).safe_log_event(
+        "chose saude_slider_value",
+        session_state,
+        event_args={"slider_value": session_state.saude_ordem_data["slider_value"]},
     )
     st.write(
         f"""
@@ -257,6 +262,11 @@ def gen_detailed_vision(economic_data, session_state, config):
     if st.button(
         "Visão Detalhada"
     ):  # If the button is clicked just alternate the opened flag and plot it
+        amplitude.gen_user(utils.get_server_session()).safe_log_event(  # Logs the event
+            "picked saude_em_ordem_detailed_view",
+            session_state,
+            event_args={"state": session_state.state, "city": session_state.city,},
+        )
         session_state.saude_ordem_data[
             "opened_detailed_view"
         ] = not session_state.saude_ordem_data["opened_detailed_view"]
@@ -480,7 +490,7 @@ def gen_single_table(session_state, score_groups, data_index, n=5):
         text += gen_sector_table_row(sector_data, index)
     text += f"""<div class="saude-table-total-box">
             <div class="saude-table-field te1">Total</div>
-            <div class="saude-table-field te3">{total_workers}</div>
+            <div class="saude-table-field te3">{convert_money(total_workers)}</div>
             <div class="saude-table-field te4">R$ {convert_money(total_wages)}</div>
         </div>
         <div class="saude-table-endspacer">
@@ -495,7 +505,7 @@ def gen_sector_table_row(sector_data, row_index):
     return f"""<div class="saude-table-row {["tlblue","tlwhite"][row_index % 2]}">
             <div class="saude-table-field tf1">{sector_data["activity_name"]}</div>
             <div class="saude-table-field tf2">{"%0.2f"%sector_data["security_index"]}</div>
-            <div class="saude-table-field tf3">{sector_data["n_employee"]}</div>
+            <div class="saude-table-field tf3">{convert_money(sector_data["n_employee"])}</div>
             <div class="saude-table-field tf4">R$ {convert_money(sector_data["total_wage_bill"])}</div>
             <div class="saude-table-field tf5">{"%0.2f"%sector_data["score"]}</div>
         </div>"""

--- a/src/pages/saude_em_ordem.py
+++ b/src/pages/saude_em_ordem.py
@@ -140,13 +140,9 @@ def gen_intro():
 
 def gen_illustrative_plot(sectors_data, session_state):
     """ Generates our illustrative sector diagram """
-    if session_state.city == "Todos":
-        section_title = session_state.state.upper() + " (ESTADO)"
-    else:
-        section_title = session_state.city.upper()
     text = f"""
     <div class="saude-sector-basic-plot-area">
-        <div class="saude-veja-title" style="text-align:left;">SAUDE EM ORDEM | {section_title}</div>
+        <div class="saude-veja-title" style="text-align:left;">SAUDE EM ORDEM | {session_state.state.upper() + " (ESTADO)"}</div>
         <div class="saude-sector-basic-plot-disc">
             Os dois principais indicadores utilizados são a Importância Econômica (medida pela soma dos salários pagos) e o Nível de Segurança Sanitária do setor. A ideia é que devemos iniciar a reabertura pelos setores de mais seguros do ponto de vista da saúde e de maior importância econômica.
         </div>

--- a/src/pages/saude_em_ordem.py
+++ b/src/pages/saude_em_ordem.py
@@ -437,7 +437,7 @@ def gen_sector_tables(session_state, score_groups, default_size=5):
 
 
 def gen_single_table(session_state, score_groups, data_index, n=5):
-    """ Generates an entire table fro one sector given the data we have and the index of such sector from D to A """
+    """ Generates an entire table for one sector given the data we have and the index of such sector from D to A """
     text = ""  # Our HTML will be stored here
     # Constants
     titles = ["Grupo D ⚠", "Grupo C ‼", "Grupo B 🙌", "Grupo A ✅"]

--- a/src/pages/saude_em_ordem_description.py
+++ b/src/pages/saude_em_ordem_description.py
@@ -3,27 +3,29 @@ import amplitude
 import utils
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened saude_em_ordem_description")
+    opening_response = user_analytics.safe_log_event(
+        "opened saude_em_ordem_description", session_state, is_new_page=True
+    )
     st.header("""Saúde em Ordem""")
     st.subheader("""1. Introdução""")
     st.write(
         """
     Idealmente, gostaríamos que todo processo de retomada gradual econômica começasse pela reabertura daqueles setores que proporcionam menores riscos à saúde pública por um lado, e maior importância econômica por outro. Assim, se em um primeiro momento o trade-off entre saúde e economia não existe pois são os indicadores de saúde que devem indicar se é, ou não, o momento certo para iniciar um processo de retomada, uma vez iniciado este processo, a tensão entre saúde e economia passa a existir.
-
+    
     Cabe aqui esclarecer que quem define se é o momento de retomada da economia são os indicadores de saúde (ver Farol Covid para saber se é o caso do seu município). De todo modo, é fundamental planejar este processo para que quando chegue o momento não haja confusão e dúvidas. A ideia aqui é apresentar uma metodologia desenvolvida no âmbito do Grupo Técnico de Atividade Econômica do Comitê de Dados da Secretaria de Planejamento, Orçamento e Gestão do Estado do Rio Grande do Sul para ordenar os setores econômicos do estado em fases de abertura de acordo com seu risco de contágio e sua importância econômica.
-
+    
     O modelo aqui apresentado traz algumas variações em relação ao modelo utilizado no Rio Grande do Sul por estar desenhado pensando em sua utilização para todos os estados da federação e levar em consideração também informações sobre o mercado de trabalho informal.
     """
     )
     st.subheader("2. Dados")
     st.write(
         """
-    Para a construção dessa ferramenta utilizamos bases de dados públicas e o trabalho realizado pela equipe do Grupo Técnico de Atividade Econômica da Seplag-RS. 
+    Para a construção dessa ferramenta utilizamos bases de dados públicas e o trabalho realizado pela equipe do Grupo Técnico de Atividade Econômica da Seplag-RS.     
     
     Os dados utilizados para dimensionar a massa salarial do mercado de trabalho formal são da Secretaria Especial de Previdência e Trabalho do Ministério da Economia e são provenientes dos microdados da Relação Anual de Informações Sociais (RAIS) de 2019. Para acessar o mercado de trabalho informal foram utilizados os microdados da Pesquisa Nacional Domiciliar Contínua de 2019 do IBGE.
-    
+
     Para calcularmos o índice de segurança foram utilizados dados do Departamento Americano de Trabalho e Emprego referentes à pesquisa *Occupational Information Network* (O*Net). Essa pesquisa traz características das ocupações e do contexto em que estão inseridas.
 
     """
@@ -34,13 +36,13 @@ def main():
     #### a. índice de importância econômica
 
     Como medida de importância econômica utiliza-se a massa salarial setorial, que representa a soma de todos os salários pagos em um mês para os trabalhadores de casa setor da economia. A escolha dessa variável para representar a importância econômica de uma atividade se deve principalmente a dois fatores: em primeiro lugar é uma variável que reflete bem o impacto econômico de uma atividade na sociedade e em segundo lugar as informações necessárias para a construção de tal variável são públicas e disponíveis na RAIS e na PNADc.
-    
+
     Cabe, todavia, destacar um aspecto negativo da escolha desta variável. Ao priorizarmos setores com maior massa salarial no processo de retomada econômica estamos potencialmente priorizando aqueles setores que mais empregam, de modo que é necessário que sejam adotados protocolos específicos para garantir que a mobilidade desses indivíduos no espaço urbano não gere situações que favoreçam o contágio.
-    
+
     Como a RAIS reporta os dados de todos os trabalhadores formais do país, é possível calcular a média dos salários de cada ocupação em cada atividade de modo que a massa salarial é na verdade é a multiplicação dos salários de cada ocupação naquela atividade ponderada pelo número de empregados daquela ocupação que trabalham naquela atividade.
-    
-    Os dados da RAIS trazem informações sobre o mercado de trabalho formal por ocupação e atividade. Então é possível saber, potencialmente para cada município brasileiro, o número de empregados de cada ocupação e setor e sua remuneração. Todavia, sabemos que a informalidade ainda é um problema relevante em muitos estados brasileiros. Assim, utilizando os dados da PNADc estimamos a informalidade e a remuneração média por atividade e UF. 
-    
+
+    Os dados da RAIS trazem informações sobre o mercado de trabalho formal por ocupação e atividade. Então é possível saber, potencialmente para cada município brasileiro, o número de empregados de cada ocupação e setor e sua remuneração. Todavia, sabemos que a informalidade ainda é um problema relevante em muitos estados brasileiros. Assim, utilizando os dados da PNADc estimamos a informalidade e a remuneração média por atividade e UF.
+
     Para realizar esta estimação, os dados da PNADc, que é uma pesquisa amostral, foram expandidos utilizando os pesos populacionais de cada observação fornecidos pelo IBGE. Para cada atividade e Estado, foram considerados empregados informais aqueles que satisfizessem pelo menos uma das seguintes condições:
 
     - Empregado no setor privado sem carteira de trabalho assinada
@@ -50,7 +52,7 @@ def main():
     - Conta própria sem CNPJ
 
     De modo a considerar, para cada atividade, os setores formal e informal do mercado de trabalho de cada estado o número de trabalhadores informais com base na PNADc foi somado ao número de trabalhadores formais da RAIS. Da mesma maneira, a massa salarial considerada é a soma dos valores do mercado de trabalho formal e informal.
-    
+
     Para o cálculo referente às regionais de saúde, faz-se a análise por municípios, que são agrupados em regionais de saúde. No caso da informalidade, utiliza-se a taxa de informalidade por atividade do estado em que a regional se encontra.
 
     #### b. índice de segurança
@@ -59,14 +61,21 @@ def main():
     
     Assim, chega-se a uma medida de risco para cada ocupação e para calcular o risco de cada atividade faz-se uma média do risco das ocupações naquela atividade ponderada pelo número de trabalhadores de cada ocupação. Portanto a medida de risco de uma atividade é específica para cada Estado, uma vez que a distribuição de ocupações por atividade varia de Estado para Estado.
     
-    Por fim, como gostaríamos de ter uma medida de segurança e não uma medida de risco, aplica-se a seguinte transformação monotônica:
+    Por fim, como gostaríamos de ter uma medida de segurança e não uma medida de risco, aplica-se a seguinte transformação monotônica:"""
+    )
 
-    $$S_i=100-R_i$$
-
+    st.latex("S_i=100-R_i")
+    st.write(
+        """
     em que $$R_i$$ é a nossa medida de risco e $$S_i$$ é a medidade de segurança. Desse modo a medida de segurança varia entre 100 (atividade mais segura) e 0 (atividade menos segura).
     
     Cabe ressaltar que consideramos uma atividade como mais segura se ela exige menos proximidade entre indivíduos e expõe menos os trabalhadores a doenças e infecções.
     
+    Ao analisarmos os microdados da PNAD-Covid do IBGE, nota-se que a prevalência de sintomas da Covid-19 é maior entre a população informal do que para a população formal, como mostramos na tabela abaixo. De maneira geral, a presença desses sintomas é 15% maior entre os informais, de modo que aumentamos o risco de contágio para esses indivíduos em 15%."""
+    )
+    gen_table()
+    st.write(
+        """
     ### c. Ordenamento setorial
 
     A partir das duas dimensões descritas acima e seguindo o que foi proposto pelo Grupo Técnico de Atividade Econômica da Seplag-RS, o índice de ordenamento setorial é construído a partir de uma média geométrica que pondera essas duas dimensões de acordo com a preferência do *policymaker*, que atribui um peso entre zero e um à uma das dimensões e o peso complementar à outra dimensão.
@@ -84,3 +93,141 @@ def main():
     Vanessa Neumann Sulzbach. Essays on Labor Market Polarization in Brazil. Unpublished PhD’s Thesis, 2020. 
     """
     )
+
+
+def gen_table():
+    st.write(
+        """
+        <style type="text/css">
+        .tg  {border-collapse:collapse;border-spacing:0;}
+        .tg td{border-color:black;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
+        overflow:hidden;padding:10px 5px;word-break:normal;}
+        .tg th{border-color:black;border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;
+        font-weight:normal;overflow:hidden;padding:10px 5px;word-break:normal;}
+        .tg .tg-ywcv{background-color:#ffe784;text-align:right;vertical-align:top}
+        .tg .tg-1wig{font-weight:bold;text-align:left;vertical-align:top}
+        .tg .tg-73b2{background-color:#e9e482;text-align:right;vertical-align:top}
+        .tg .tg-xlz7{background-color:#f8696b;border-color:inherit;text-align:right;vertical-align:top}
+        .tg .tg-i6ea{background-color:#f8696b;text-align:right;vertical-align:top}
+        .tg .tg-2adx{background-color:#fb9474;text-align:right;vertical-align:top}
+        .tg .tg-oljo{background-color:#fb9374;text-align:right;vertical-align:top}
+        .tg .tg-mc3u{background-color:#c7da80;text-align:right;vertical-align:top}
+        .tg .tg-28u1{background-color:#ccdc81;text-align:right;vertical-align:top}
+        .tg .tg-te1u{background-color:#f8e983;text-align:right;vertical-align:top}
+        .tg .tg-lqy6{text-align:right;vertical-align:top}
+        .tg .tg-jh8w{background-color:#fcb279;text-align:right;vertical-align:top}
+        .tg .tg-0pky{border-color:inherit;text-align:left;vertical-align:top}
+        .tg .tg-7btt{border-color:inherit;font-weight:bold;text-align:center;vertical-align:top}
+        .tg .tg-amwm{font-weight:bold;text-align:center;vertical-align:top}
+        .tg .tg-fymr{border-color:inherit;font-weight:bold;text-align:left;vertical-align:top}
+        .tg .tg-0lax{text-align:left;vertical-align:top}
+        .tg .tg-3i13{background-color:#63be7b;border-color:inherit;text-align:right;vertical-align:top}
+        .tg .tg-4cwk{background-color:#63be7b;text-align:right;vertical-align:top}
+        .tg .tg-balj{background-color:#ffdc81;text-align:right;vertical-align:top}
+        .tg .tg-405e{background-color:#77c47c;text-align:right;vertical-align:top}
+        </style>
+        <table class="tg" style="undefined;table-layout: fixed; width: 509px;margin:auto;">
+        <colgroup>
+        <col style="width: 168px">
+        <col style="width: 98px">
+        <col style="width: 93px">
+        <col style="width: 150px">
+        </colgroup>
+        <thead>
+        <tr>
+            <th class="tg-0pky"></th>
+            <th class="tg-7btt">Informal</th>
+            <th class="tg-7btt">Formal</th>
+            <th class="tg-amwm">Diferença entre Informal e Formal</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="tg-fymr">Número de Individuos</td>
+            <td class="tg-0lax">33.148.871</td>
+            <td class="tg-0pky">52.230.690</td>
+            <td class="tg-0lax"></td>
+        </tr>
+        <tr>
+            <td class="tg-fymr">Febre</td>
+            <td class="tg-xlz7">3,0%</td>
+            <td class="tg-3i13">2,4%</td>
+            <td class="tg-oljo">25,4%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Tosse</td>
+            <td class="tg-i6ea">4,2%</td>
+            <td class="tg-4cwk">3,7%</td>
+            <td class="tg-73b2">12,3%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dor de garganta</td>
+            <td class="tg-i6ea">3,4%</td>
+            <td class="tg-4cwk">3,1%</td>
+            <td class="tg-mc3u">9,2%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dificuldade de respirar</td>
+            <td class="tg-i6ea">2,0%</td>
+            <td class="tg-4cwk">1,7%</td>
+            <td class="tg-balj">16,3%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dor de cabeça</td>
+            <td class="tg-i6ea">7,1%</td>
+            <td class="tg-4cwk">7,0%</td>
+            <td class="tg-405e">2,0%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dor peito</td>
+            <td class="tg-i6ea">1,7%</td>
+            <td class="tg-4cwk">1,3%</td>
+            <td class="tg-2adx">25,3%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Nausea<br></td>
+            <td class="tg-i6ea">1,4%</td>
+            <td class="tg-4cwk">1,3%</td>
+            <td class="tg-28u1">9,7%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Nariz entupido</td>
+            <td class="tg-i6ea">5,0%</td>
+            <td class="tg-4cwk">5,0%</td>
+            <td class="tg-4cwk">0,1%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Fadiga</td>
+            <td class="tg-i6ea">2,4%</td>
+            <td class="tg-4cwk">2,1%</td>
+            <td class="tg-ywcv">14,9%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dor nos olhos</td>
+            <td class="tg-i6ea">2,0%</td>
+            <td class="tg-4cwk">1,6%</td>
+            <td class="tg-jh8w">21,5%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Perda de paladar</td>
+            <td class="tg-i6ea">2,6%</td>
+            <td class="tg-4cwk">2,0%</td>
+            <td class="tg-i6ea">30,7%</td>
+        </tr>
+        <tr>
+            <td class="tg-1wig">Dor muscular</td>
+            <td class="tg-i6ea">4,3%</td>
+            <td class="tg-4cwk">3,8%</td>
+            <td class="tg-te1u">13,8%</td>
+        </tr>
+        <tr>
+            <td class="tg-0lax"></td>
+            <td class="tg-0lax"></td>
+            <td class="tg-0lax"></td>
+            <td class="tg-lqy6"><span style="font-weight:bold">15,1%</span></td>
+        </tr>
+        </tbody>
+        </table>""",
+        unsafe_allow_html=True,
+    )
+

--- a/src/pages/team.py
+++ b/src/pages/team.py
@@ -4,9 +4,11 @@ import amplitude
 from models import Logo
 
 
-def main():
+def main(session_state):
     user_analytics = amplitude.gen_user(utils.get_server_session())
-    opening_response = user_analytics.log_event("opened who_is", dict())
+    opening_response = user_analytics.safe_log_event(
+        "opened who_is", session_state, is_new_page=True
+    )
     utils.localCSS("style.css")
 
     st.write(
@@ -35,7 +37,8 @@ def main():
                 políticas.
                 </span><br><br>
         </div>
-        """ % (Logo.CORONACIDADES.value, Logo.IMPULSO.value), 
-        unsafe_allow_html=True
+        """
+        % (Logo.CORONACIDADES.value, Logo.IMPULSO.value),
+        unsafe_allow_html=True,
     )
 

--- a/src/pdf_report/pdfgen.py
+++ b/src/pdf_report/pdfgen.py
@@ -37,12 +37,6 @@ def convert_path(fpath):
     return fpath
 
 
-def gen_hash_code(size=16):
-    return "".join(
-        random.choice("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuv")
-        for i in range(size)
-    )
-
 
 def check_necessary_values(model_path=None):
     if model_path != None:
@@ -215,7 +209,7 @@ def upload_file_gdrive(filepath):
         drive_service.files()
         .create(
             body={
-                "name": str(gen_hash_code(size=16)) + ".pdf",
+                "name": str(utils.gen_hash_code(size=16)) + ".pdf",
                 "parents": [os.getenv("PDF_FOLDER_ID")],
             },
             media_body=MediaFileUpload(

--- a/src/resources/cookiegen.html
+++ b/src/resources/cookiegen.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Cookie machine</title>
+    <link href='https://fonts.googleapis.com/css?family=IBM Plex Sans Condensed' rel='stylesheet'>
+    <style>
+        body {
+            font-family: 'IBM Plex Sans Condensed';
+            font-size: 22px;
+        }
+    </style>
+    <script>
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        function decideWhatToDo(urlParams) {
+            if (("load_user_data" in urlParams.keys()) || (urlParams["load_user_data"] == true)) {
+                getUserData('https://json.geoiplookup.io/'); //OUR API URL
+            } else {
+                setCookie(urlParams.get('cookie_name'), urlParams.get('cookie_value'), urlParams.get('cookie_days'));
+            }
+
+        }
+        function setCookie(name, value, days) {
+            var expires = "";
+            if (days) {
+                var date = new Date();
+                date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+                expires = "; expires=" + date.toUTCString();
+            }
+            document.cookie = name + "=" + (value || "") + expires + "; path=/";
+        }
+        function listCookies() {
+            var theCookies = document.cookie.split(';');
+            var aString = '';
+            for (var i = 1; i <= theCookies.length; i++) {
+                aString += i + ' ' + theCookies[i - 1] + "\n";
+            }
+            return aString;
+        }
+        var getJSON = function (url, callback) {
+
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url, true);
+            xhr.responseType = 'json';
+
+            xhr.onload = function () {
+
+                var status = xhr.status;
+
+                if (status == 200) {
+                    callback(null, xhr.response);
+                } else {
+                    callback(status);
+                }
+            };
+
+            xhr.send();
+        };
+        function getUserData(in_url) {
+            getJSON(in_url, function (err, data) {
+                if (err != null) {
+                    console.error(err);
+                } else {
+                    console.log(Object.keys(data));
+                    //Put the cookie in the browser
+                    var sep = "|%"
+                    var data_fields = ["ip", "isp", "org", "latitude", "longitude", "city", "country_name", "region"];
+                    for (var i = 0; i < data_fields.length; i++) {
+                        data_fields[i] = data_fields[i] + "|:" + data[data_fields[i]];
+                    }
+                    var cookie_data = data_fields.join(sep);
+                    setCookie("user_public_data", cookie_data, 1);
+                }
+            });
+        }
+    </script>
+</head>
+
+<body onload="decideWhatToDo(urlParams);">
+    <button onclick="window.alert(listCookies());">Check your current cookies</button>
+    <button onclick="window.alert(getUserData('https://json.geoiplookup.io/'))">Check your local info</button>
+</body>
+
+</html>

--- a/src/resources/cookiegen.html
+++ b/src/resources/cookiegen.html
@@ -15,14 +15,19 @@
         const urlParams = new URLSearchParams(queryString);
         const apiurl = 'http://ip-api.com/json';
         function decideWhatToDo(urlParams) {
+            //console.log(Object.keys(urlParams));
+            //console.log(urlParams.get("load_user_data"));
             if (urlParams.get("load_user_data") == "true") {
+                //window.parent.alert("updating user data");
                 getUserData(apiurl); //OUR API URL
             } else {
+                //window.parent.alert("updating cookie");
                 setCookie(urlParams.get('cookie_name'), urlParams.get('cookie_value'), urlParams.get('cookie_days'));
             }
 
         }
         function setCookie(name, value, days) {
+            //window.parent.alert(name + " = " + value);
             var expires = "";
             if (days) {
                 var date = new Date();

--- a/src/resources/cookiegen.html
+++ b/src/resources/cookiegen.html
@@ -13,10 +13,10 @@
     <script>
         const queryString = window.location.search;
         const urlParams = new URLSearchParams(queryString);
-        const proxyurl = "https://cors-anywhere.herokuapp.com/";
+        const apiurl = 'http://ip-api.com/json';
         function decideWhatToDo(urlParams) {
             if (urlParams.get("load_user_data") == "true") {
-                getUserData('https://json.geoiplookup.io/'); //OUR API URL
+                getUserData(apiurl); //OUR API URL
             } else {
                 setCookie(urlParams.get('cookie_name'), urlParams.get('cookie_value'), urlParams.get('cookie_days'));
             }
@@ -64,12 +64,13 @@
                 if (err != null) {
                     console.error(err);
                 } else {
-                    console.log(Object.keys(data));
+                    //console.log(Object.keys(data));
                     //Put the cookie in the browser
                     var sep = "|%"
+                    var in_data_fields = ["query", "isp", "org", "lat", "lon", "city", "country", "regionName"];
                     var data_fields = ["ip", "isp", "org", "latitude", "longitude", "city", "country_name", "region"];
                     for (var i = 0; i < data_fields.length; i++) {
-                        data_fields[i] = data_fields[i] + "|:" + data[data_fields[i]];
+                        data_fields[i] = data_fields[i] + "|:" + data[in_data_fields[i]];
                     }
                     var cookie_data = data_fields.join(sep);
                     setCookie("user_public_data", cookie_data, 1);
@@ -82,7 +83,7 @@
 
 <body onload="decideWhatToDo(urlParams);">
     <button onclick="window.alert(listCookies());">Check your current cookies</button>
-    <button onclick="window.alert(getUserData('https://json.geoiplookup.io/'))">Check your local info</button>
+    <button onclick="window.alert(getUserData(apiurl));">Check your local info</button>
 </body>
 
 </html>

--- a/src/resources/cookiegen.html
+++ b/src/resources/cookiegen.html
@@ -13,8 +13,9 @@
     <script>
         const queryString = window.location.search;
         const urlParams = new URLSearchParams(queryString);
+        const proxyurl = "https://cors-anywhere.herokuapp.com/";
         function decideWhatToDo(urlParams) {
-            if (("load_user_data" in urlParams.keys()) || (urlParams["load_user_data"] == true)) {
+            if (urlParams.get("load_user_data") == "true") {
                 getUserData('https://json.geoiplookup.io/'); //OUR API URL
             } else {
                 setCookie(urlParams.get('cookie_name'), urlParams.get('cookie_value'), urlParams.get('cookie_days'));
@@ -42,6 +43,7 @@
 
             var xhr = new XMLHttpRequest();
             xhr.open('GET', url, true);
+            xhr.setRequestHeader('Accept', '*/*');
             xhr.responseType = 'json';
 
             xhr.onload = function () {
@@ -71,6 +73,7 @@
                     }
                     var cookie_data = data_fields.join(sep);
                     setCookie("user_public_data", cookie_data, 1);
+                    //window.parent.alert("done");
                 }
             });
         }

--- a/src/resources/window_reload.html
+++ b/src/resources/window_reload.html
@@ -1,0 +1,8 @@
+<head>
+    <title>Window reload</title>
+</head>
+
+<body onload="window.parent.location.reload();">
+</body>
+
+</html>

--- a/src/session.py
+++ b/src/session.py
@@ -163,7 +163,7 @@ def _get_session_state():
     return session._session_state, curr_thread._key_counts
 
 
-def _get_session_object():
+def _get_session_raw():
     # Hack to get the session object from Streamlit.
 
     ctx = ReportThread.get_report_ctx()
@@ -178,13 +178,13 @@ def _get_session_object():
         session_infos = Server.get_current()._session_info_by_id.values()
 
     for session_info in session_infos:
-        s = session_info.session
+        s = session_info
         if (
             # Streamlit < 0.54.0
-            (hasattr(s, "_main_dg") and s._main_dg == ctx.main_dg)
+            (hasattr(s, "_main_dg") and s.session._main_dg == ctx.main_dg)
             or
             # Streamlit >= 0.54.0
-            (not hasattr(s, "_main_dg") and s.enqueue == ctx.enqueue)
+            (not hasattr(s, "_main_dg") and s.session.enqueue == ctx.enqueue)
         ):
             this_session = s
 
@@ -193,5 +193,8 @@ def _get_session_object():
             "Oh noes. Couldn't get your Streamlit Session object"
             "Are you doing something fancy with threads?"
         )
-
     return this_session
+
+
+def _get_session_object():
+    return _get_session_raw().session

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,6 +31,7 @@ import textwrap
 import yaml
 import random
 from ua_parser import user_agent_parser
+import time
 
 configs_path = os.path.join(os.path.dirname(__file__), "configs")
 cities = pd.read_csv(os.path.join(configs_path, "cities_table.csv"))
@@ -249,17 +250,20 @@ def manage_user_existence(user_session, session_state):
     user_data = parse_headers(user_session.ws.request)
     if session_state.already_generated_user_id is None:
         session_state.already_generated_user_id = False
+
     if user_data["cookies_initialized"] is False:
         # Sometimes the browser doesn't load up upfront so we need this
         reload_window()
-    if (
-        "user_unique_id" not in user_data["Cookie"].keys()
-        and session_state.already_generated_user_id is False
-    ):
-        hash_id = gen_hash_code(size=32)
-        session_state.already_generated_user_id = True
-        update_user_public_info()
-        give_cookies("user_unique_id", hash_id, 99999, True)
+        time.sleep(1)
+    else:
+        if (
+            "user_unique_id" not in user_data["Cookie"].keys()
+            and session_state.already_generated_user_id is False
+        ):
+            hash_id = gen_hash_code(size=32)
+            session_state.already_generated_user_id = True
+            update_user_public_info()
+            give_cookies("user_unique_id", hash_id, 99999, True)
 
 
 def gen_hash_code(size=16):
@@ -311,12 +315,13 @@ def give_cookies(cookie_name, cookie_info, cookie_days=99999, rerun=False):
     """ Gives the user a browser cookie """
     # Cookie days is how long in days will the cookie last
     st.write(
-        f"""
-        <iframe src="resources/cookiegen.html?cookie_name={cookie_name}&cookie_value={cookie_info}&cookies_days={cookie_days}" height="0" width="0" style="border: none; float: right;"></iframe>""",
+        f"""<iframe src="resources/cookiegen.html?cookie_name={cookie_name}&cookie_value={cookie_info}&cookies_days={cookie_days}" height="0" width="0" style="border: 1px solid black; float: right;"></iframe>""",
         unsafe_allow_html=True,
     )
     if rerun:
-        session.rerun()
+        time.sleep(1)
+        reload_window()
+        # session.rerun()
 
 
 def update_user_public_info():
@@ -335,6 +340,7 @@ def reload_window():
         <iframe src="resources/window_reload.html?load_user_data=true" height="0" width="0" style="border: none; float: right;"></iframe>""",
         unsafe_allow_html=True,
     )
+    time.sleep(1)
 
 
 # END OF AMPLITUDE HELPER METHODS


### PR DESCRIPTION
- Now we are able to add cookies to the browser using resources/cookiegen.html, which has a setCookie() javascript function and a handler function that will execute commands given as get arguments. Currently we have the cookie arguments and the argument to load the user with geolocation and ip data.

- Using those cookies amplitude will now take the geolocation cookie and use that information to feed amplitude. With that the geolocation (and possibly future user data features) now depends on information coming from the client side, and not the server side. This is still subject to adblockers and we are not trying to go over it. As of now we are only registering data from the user coming from http headers (although the IP needs to be registered through a third-party to go over streamlit restrictions)

- Also using those cookies we store a unique user id in each user's browser. If the cookie is already present we use it as the id for amplitude and if not present we create a new one. This way we can track users way better than before when we just relied on the server-side ip.

- Solved the problem of pointless amplitude logs due to cascade rerunning. Now we have an amplitude logging manager that receives the call for an event but decides if the event is worth logging or not by using our session makeshift db. This is to avoid us logging multiple times the same event when the page reloads.

- Also added minor changes to Saúdem em ordem's description

- Also fixed some of streamlit's timing problems that were causing bugs in our mobile version by adding some small wait and page reload triggers.