### PR TITLE
Makes the sidebar auto close when the user loads the page

### DIFF
--- a/src/farolcovid.py
+++ b/src/farolcovid.py
@@ -52,6 +52,13 @@ def main():
     # which in turn allows us to decide if we should log the event or not"""
     utils.manage_user_existence(utils.get_server_session(), session_state)
     utils.update_user_public_info()
+    # CLOSES THE SIDEBAR WHEN THE USER LOADS THE PAGE
+    st.write(
+        """
+    <iframe src="resources/sidebar-closer.html" height=0 width=0">
+    </iframe>""",
+        unsafe_allow_html=True,
+    )
     # For Http debug
     # st.write(utils.parse_headers(utils.get_server_session().ws.request))
     page = st.sidebar.radio(

--- a/src/resources/sidebar-closer.html
+++ b/src/resources/sidebar-closer.html
@@ -1,0 +1,16 @@
+<head>
+</head>
+<script>
+    function close_sidebar() {
+        sideCloseSection = window.parent.document.querySelectorAll(".sidebar:not(.--collapsed)");
+        sideCloseButt = window.parent.document.getElementsByClassName("sidebar-close btn btn-outline-secondary")[0];
+        if (sideCloseSection[0]) {
+            sideCloseButt.click();
+        }
+    }
+
+</script>
+
+<body onload="close_sidebar();">
+    <button onclick="close_sidebar();" style="position: relative;">Click here to close the sidebar</button>
+</body>


### PR DESCRIPTION
Now, instead of it being open at first, when the user opens farolcovid a js script will close the sidebar. Allowing for a much better user experience.