### PR TITLE
Rt Methodology Text: Fixing typo in Bayes' Rule

### DIFF
--- a/src/pages/rt_description.py
+++ b/src/pages/rt_description.py
@@ -55,7 +55,7 @@ def main(session_state):
     )
 
     st.latex(
-        r"""P(k_t) = \sum_{R_t} P(k_t \mid R_t) P(R_t) \rightarrow P(R_t \mid k_t) = \frac{P(R_t \mid k_t) P(R_t)}{P(k_t)}"""
+        r"""P(k_t) = \sum_{R_t} P(k_t \mid R_t) P(R_t) \rightarrow P(R_t \mid k_t) = \frac{P(k_t \mid R_t) P(R_t)}{P(k_t)}"""
     )
 
     st.subheader("""Considerações""")


### PR DESCRIPTION
Just a quick fix on a typo. 

At the end of the Rt methodology section, Bayes' Rule is introduced for calculating the current value of Rt. Currently, it shows up like this:

![image](https://user-images.githubusercontent.com/16492682/98981543-d9d67080-24fc-11eb-822f-8683fac4c8ef.png)

When it should be:

![image](https://user-images.githubusercontent.com/16492682/98981903-55d0b880-24fd-11eb-89f2-6e9f9f2cfb2e.png)