### PR TITLE
OndaCovid adjustments

### DIFF
--- a/src/pages/data_analysis.py
+++ b/src/pages/data_analysis.py
@@ -177,6 +177,10 @@ def plot_heatmap(
 
     st.plotly_chart(fig, use_container_width=True)
 
+    # Display Note about Missing Data and Moving Averages
+    st.write("<i>Nossos gráficos dependem de dados públicos. Eventuais dados faltantes são uma consequência de dias em que nossas fontes não reportaram uma coleta. Caso um município ou estado tenha mais de três dias consecutivos de dados faltantes, não calculamos uma média móvel para a data.</i>",
+    unsafe_allow_html=True)
+
 
 def _generate_mvg_deaths(df, place_type, mavg_days, min_periods, deaths_per_cases=False):
     # Consolidate Entries according to Place Type
@@ -289,7 +293,6 @@ def gen_cards(df, your_city, group):
         unsafe_allow_html=True,
     )
 
-
 # @st.cache(suppress_st_warning=True)
 def prepare_heatmap(
     df, place_type, group=None, mavg_days=7, min_periods=4, your_city=None, deaths_per_cases=False
@@ -323,7 +326,7 @@ def prepare_heatmap(
         df.groupby(place_type)[[col_deaths]].max().reset_index().sort_values(col_deaths)
     )
 
-    # Prepare HTML for Cities
+    # Prepare Introductory Text for Cities Heatmap
     if place_type == "city_name":
 
         gen_cards(df, your_city, group)
@@ -337,8 +340,6 @@ def prepare_heatmap(
             maior número de mortes por dia observado no município
             até hoje</b>.
             <br><br>
-            Dependemos de dados públicos. Eventuais dados faltantes são uma consequência de dias em que nossas fontes não reportaram uma coleta. Nosso cálculo da média móvel leva em consideração pequenas interrupções nos dados. Quando dados faltantes representam menos de quatro dos últimos sete dias, calculamos a média móvel com base nos dias remascentes para os quais temos dados. 
-            <br><br>
             Os municípios estão ordenadas pelo dia que atingiu o máximo de mortes, 
             ou seja, municípios no pico de mortes aparecerão no topo. {}
             é o município com o maior número de mortos com: <i>{}</i>
@@ -348,7 +349,7 @@ def prepare_heatmap(
         </div>
         """
 
-    # Prepare HTML for States
+    # Prepare Introductory Text for States Heatmap
     if place_type == "state_id":
 
         legend = """
@@ -363,8 +364,6 @@ def prepare_heatmap(
                 <b>quanto mais vermelho, mais próximo está o valor do
                 maior número de mortes por dia observado na UF até hoje</b>.
                 <br><br>
-                Dependemos de dados públicos. Eventuais dados faltantes são uma consequência de dias em que nossas fontes não reportaram uma coleta. Sendo assim, é possível que em determinadas datas os números estaduais sejam menores por conta de municípios que não notificaram mortes. Nosso cálculo da média móvel leva em consideração pequenas interrupções nos dados. Quando dados faltantes representam menos de quatro dos últimos sete dias, calculamos a média móvel com base nos dias remascentes para os quais temos dados. 
-                <br><br>
                 As UFs estão ordenadas pelo dia que atingiram o máximo de mortes, 
                 ou seja, UFs no pico de mortes aparecerão no topo. {}
                 é o estado com o maior número de mortos com: <i>{}</i>
@@ -375,7 +374,7 @@ def prepare_heatmap(
         </div>
         """
 
-    # Prepare HTML for Countries
+    # Prepare Introductory Text for Countries Heatmap
     if place_type == "country_pt":
 
         legend = """

--- a/src/pages/data_analysis.py
+++ b/src/pages/data_analysis.py
@@ -336,7 +336,7 @@ def prepare_heatmap(
                 <b>quanto mais vermelho, mais próximo está o valor do
                 maior número de mortes por dia observado na UF até hoje</b>.
                 <br><br>
-                As UFs estão ordenadas pelo dia que atingiu o máximo de mortes, 
+                As UFs estão ordenadas pelo dia que atingiram o máximo de mortes, 
                 ou seja, UFs no pico de mortes aparecerão no topo. {}
                 é o estado com o maior número de mortos com: <i>{}</i>
                 e o Brasil totaliza: <i>{}</i>.
@@ -360,7 +360,7 @@ def prepare_heatmap(
             mais próximo está o valor do maior número de mortes por
             dia observado no país até hoje</b>.
             <br><br>
-            Os países estão ordernados pelo dia que atingiu o máximo de mortes,
+            Os países estão ordernados pelo dia que atingiram o máximo de mortes,
             ou seja, os países no pico de mortes aparecerão no topo. {}
             é o país com o maior número de mortos com: <i>{}</i>
             e o mundo totaliza: <i>{}</i>.
@@ -402,17 +402,17 @@ def prepare_heatmap(
                 "{:,.0f}".format(place_max_deaths.iloc[0]).replace(',','.'),
                 "{:,.0f}".format(place_max_deaths.values[int(len(place_max_deaths.values) / 2)]).replace(',','.'),
                 refresh[:10],
-            ).replace(',','.'),
+            ),
             unsafe_allow_html=True,
         )
     else:
         st.write(
             legend.format(
-                "{:,.0f}".format(place_max_deaths.iloc[-1][place_type]).replace(',','.'),
+                "{}".format(place_max_deaths.iloc[-1][place_type]),
                 "{:,.0f}".format(place_max_deaths.max()[col_deaths]).replace(',','.'),
                 "{:,.0f}".format(place_max_deaths.sum()[col_deaths]).replace(',','.'),
                 refresh[:10],
-            ).replace(',','.'),
+            ),
             unsafe_allow_html=True,
         )
 

--- a/src/pages/data_analysis.py
+++ b/src/pages/data_analysis.py
@@ -315,7 +315,7 @@ def prepare_heatmap(
             <br><br>
             Os municípios estão ordenadas pelo dia que atingiu o máximo de mortes, 
             ou seja, municípios no pico de mortes aparecerão no topo. {}
-            é o município com o maior número de mortos, com: <i>{}</i>
+            é o município com o maior número de mortos com: <i>{}</i>
             e o estado totaliza: <i>{}</i>.
             <br><br>
             <i>Última atualização: {}</i>
@@ -338,7 +338,7 @@ def prepare_heatmap(
                 <br><br>
                 As UFs estão ordenadas pelo dia que atingiu o máximo de mortes, 
                 ou seja, UFs no pico de mortes aparecerão no topo. {}
-                é o estado com o maior número de mortos, com: <i>{}</i>
+                é o estado com o maior número de mortos com: <i>{}</i>
                 e o Brasil totaliza: <i>{}</i>.
                 <br><br>
                 <i>Última atualização: {}</i>
@@ -362,7 +362,7 @@ def prepare_heatmap(
             <br><br>
             Os países estão ordernados pelo dia que atingiu o máximo de mortes,
             ou seja, os países no pico de mortes aparecerão no topo. {}
-            é o país com o maior número de mortos, com: <i>{}</i>
+            é o país com o maior número de mortos com: <i>{}</i>
             e o mundo totaliza: <i>{}</i>.
             <br><br>
             <i>Última atualização: {}</i>
@@ -379,7 +379,7 @@ def prepare_heatmap(
             <br><br>
             Os municípios estão ordenadas pelo dia que atingiram o seu máximo de mortes por casos, 
             ou seja, municípios no pico de mortes por casos aparecerão no topo. 
-            {} é o município com o maior número de mortos por casos, com: <i>{}</i> mortos por casos
+            {} é o município com o maior número de mortos por casos com: <i>{}</i> mortos por casos
             e o estado tem uma mediana de: <i>{}</i> mortos por casos.
             <br><br>
             <i>Última atualização: {}</i>
@@ -399,21 +399,20 @@ def prepare_heatmap(
         st.write(
             legend.format(
                 place_max_deaths.index[0],
-                "%0.3f" % place_max_deaths.iloc[0],
-                "%0.3f"
-                % place_max_deaths.values[int(len(place_max_deaths.values) / 2)],
+                "{:,.0f}".format(place_max_deaths.iloc[0]).replace(',','.'),
+                "{:,.0f}".format(place_max_deaths.values[int(len(place_max_deaths.values) / 2)]).replace(',','.'),
                 refresh[:10],
-            ),
+            ).replace(',','.'),
             unsafe_allow_html=True,
         )
     else:
         st.write(
             legend.format(
-                place_max_deaths.iloc[-1][place_type],
-                place_max_deaths.max()[col_deaths],
-                place_max_deaths.sum()[col_deaths],
+                "{:,.0f}".format(place_max_deaths.iloc[-1][place_type]).replace(',','.'),
+                "{:,.0f}".format(place_max_deaths.max()[col_deaths]).replace(',','.'),
+                "{:,.0f}".format(place_max_deaths.sum()[col_deaths]).replace(',','.'),
                 refresh[:10],
-            ),
+            ).replace(',','.'),
             unsafe_allow_html=True,
         )
 


### PR DESCRIPTION
This PR makes a few changes to the OndaCovid feature:

- Number of deaths now appears without the decimal separator. A thousands separator has been added and appears as a period.
- Heatmaps now display missing data. In addition to the visualization, the hover text also informs the user of unavailable data.
- The moving average function has been updated. Averages are now calculated as long as there is valid data for at least 4 of the last 7 days.
- A notice about the missing data and the moving average has been added to the user interface.
- Rework around the code for plotting heatmaps, as well as a few tweaks and comments.